### PR TITLE
Fix multiline range start marker not indexed after a lone '?' line

### DIFF
--- a/src/features/link-creation/__tests__/multiline-range-marker-insertion.test.ts
+++ b/src/features/link-creation/__tests__/multiline-range-marker-insertion.test.ts
@@ -203,6 +203,60 @@ describe("link-creation/gen_insert_blocklink_multiline_block", () => {
 		);
 	});
 
+	test("pushes the start marker to the true end of a merged paragraph when a lone '?' line precedes a list", () => {
+		// Regression test for a bug report: "Paragraph line one." + "?" merge into one
+		// paragraph section (no blank line breaks them apart), and the following list
+		// swallows "Final paragraph line." as a lazy-continuation of its last item.
+		// Section/listItem shapes below were captured from a real Obsidian metadataCache
+		// dump for this exact text, not hand-guessed.
+		jest.spyOn(Utils, "generateRandomId").mockReturnValue("abc123");
+
+		const editor = new TestEditor(
+			[
+				"Paragraph line one.",
+				"?",
+				"- Bullet point one.",
+				"- Bullet point two.",
+				"Final paragraph line.",
+			].join("\n"),
+			{ line: 0, ch: 0 },
+			{ line: 4, ch: 0 }
+		);
+
+		const fileCache: any = {
+			sections: [
+				{
+					type: "paragraph",
+					position: { start: { line: 0, col: 0 }, end: { line: 1, col: 1 } },
+				},
+				{
+					type: "list",
+					position: { start: { line: 2, col: 0 }, end: { line: 4, col: 22 } },
+				},
+			],
+			listItems: [
+				{ position: { start: { line: 2, col: 0 }, end: { line: 2, col: 19 } } },
+				{ position: { start: { line: 3, col: 0 }, end: { line: 4, col: 22 } } },
+			],
+		};
+
+		const result = gen_insert_blocklink_multiline_block(fileCache, editor as any, DEFAULT_SETTINGS);
+
+		expect(result).toEqual({ ok: true, link: "^abc123-abc123" });
+		// Start marker MUST land on the "?" line (the paragraph's real last line), not on
+		// "Paragraph line one." — Obsidian silently drops a block id that isn't at the
+		// true end of its enclosing block, which was the root cause of the bug.
+		expect(editor.getValue()).toBe(
+			[
+				"Paragraph line one.",
+				"? ^abc123",
+				"- Bullet point one.",
+				"- Bullet point two.",
+				"Final paragraph line. ^abc123-abc123",
+			].join("\n")
+		);
+	});
+
 	test("reuses an existing inline range marker without modifying the document", () => {
 		const spy = jest.spyOn(Utils, "generateRandomId");
 		spy.mockClear();

--- a/src/features/link-creation/index.ts
+++ b/src/features/link-creation/index.ts
@@ -335,8 +335,40 @@ export function gen_insert_blocklink_multiline_block(
 	const startListItem = pickListItemForLine(startLine);
 	const endListItem = pickListItemForLine(endLine);
 
-	const startInsertLine = startListItem ? startListItem.end : startLine;
 	const endInsertLine = endListItem ? endListItem.end : endLine;
+
+	// Obsidian only indexes a block id if it sits on the true last line of its
+	// enclosing block. Consecutive non-blank lines merge into one "paragraph"
+	// section (e.g. a lone `?` line does not break the paragraph above it), so
+	// `startLine` may not be that section's real last line. Placing `^id` there
+	// is silently ignored by Obsidian's block cache.
+	//
+	// This is normally masked: when the end marker lands inside that same
+	// section, the range resolver (getLineRangeFromRef) falls back to that
+	// section's own position, which still starts at the right line. But once
+	// the end marker lands in a *different* section (e.g. a following list
+	// swallows the next paragraph as a lazy-continuation line), the fallback
+	// no longer covers the true start, and the range collapses to just the end
+	// block. Extend the start marker to its section's real last line in that
+	// case only, mirroring how wrapped list items already push the marker to
+	// `startListItem.end` above.
+	const startSection = !startListItem
+		? (fileCache.sections || []).find((section) => {
+				return section.position.start.line <= startLine && section.position.end.line >= startLine;
+			})
+		: undefined;
+
+	const startNeedsSectionExtension =
+		Boolean(startSection) &&
+		startSection!.type !== "list" &&
+		startSection!.position.end.line > startLine &&
+		endInsertLine > startSection!.position.end.line;
+
+	const startInsertLine = startListItem
+		? startListItem.end
+		: startNeedsSectionExtension
+			? startSection!.position.end.line
+			: startLine;
 
 	const startInsertText = editor.getLine(startInsertLine);
 	const endInsertText = editor.getLine(endInsertLine);


### PR DESCRIPTION
"Add multi-line block" fails to bridge the full selection when a standalone `?` line is immediately followed by a list item. Only the last selected line renders in the resulting embed, and the `^id-id` marker shows up as literal visible text instead of being resolved.

Consecutive non-blank lines merge into one paragraph section in Obsidian's markdown parser, so a lone `?` line does not break the paragraph above it. Obsidian only indexes a `^id` block marker when it sits on the true last line of its enclosing block, so the start marker was silently dropped whenever it landed mid-paragraph.

This was usually masked by a fallback in the range resolver (it recovers correctly when the end marker lands in the same section), but broke when a following list swallowed the next paragraph as a lazy-continuation line, putting the end marker in a different section. The fallback then collapsed the range to just that last line.

Extend the start marker to its section's real last line whenever the end marker will land outside that section, mirroring the existing handling for wrapped list items. Verified against real Obsidian metadataCache dumps for the failing structure.

Testing: added a regression test using section/listItem shapes captured directly from Obsidian's metadataCache for this exact input. Full existing suite still passes (228/228), tsc clean.